### PR TITLE
Use Linear layout instead of Contraint Layout

### DIFF
--- a/app/src/main/res/layout/item_file.xml
+++ b/app/src/main/res/layout/item_file.xml
@@ -1,41 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
-    android:padding="8dp">
-
-    <TextView
-        android:id="@+id/tv_file_name"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
-        android:layout_marginStart="8dp"
-        android:text="@string/file__default_name"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/img_file_type"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.523" />
-
-    <TextView
-        android:id="@+id/tv_last_modified_time"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/file_default_last_modified_time"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:padding="8dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
 
     <ImageView
         android:id="@+id/img_file_type"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_common_file_24" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:paddingStart="2dp"
+        android:paddingEnd="0dp"
+        android:src="@drawable/ic_common_file_24"
+        android:contentDescription="@string/folder" />
+
+    <TextView
+        android:id="@+id/tv_file_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingStart="10dp"
+        android:paddingEnd="5dp"
+        android:ellipsize="none"
+        android:singleLine="false"
+        android:text="@string/file__default_name" />
+
+    <TextView
+        android:id="@+id/tv_last_modified_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:text="@string/file_default_last_modified_time" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
 
     <string name="file__default_name">default-file-name</string>
     <string name="file_default_last_modified_time">default-last-modified-time</string>
+    <string name="folder">Folder</string>
 </resources>


### PR DESCRIPTION
Continuing on this issue: https://github.com/Navi-Cloud/Navi-App/issues/9

Linearlayout does take account of each element each other. aka, meaning each component is dependent. 
In this way, we are able to split name-LMT area automatically, and supports rotation - view as well. Aka if we use constraint layout, it mess up output when its width dp is not enough. 